### PR TITLE
urdf: rename ignition-gazebo plugins to gz-sim (Gazebo Harmonic)

### DIFF
--- a/urdf/ayg_sim_ros2_control.xacro
+++ b/urdf/ayg_sim_ros2_control.xacro
@@ -98,8 +98,8 @@
 
         <xacro:if value="${gazebo_version == 'fortress'}">
             <gazebo>
-                <plugin filename="ignition-gazebo-odometry-publisher-system"
-                        name="ignition::gazebo::systems::OdometryPublisher">
+                <plugin filename="gz-sim-odometry-publisher-system"
+                        name="gz::sim::systems::OdometryPublisher">
                     <odom_frame>Base</odom_frame>
                     <robot_base_frame>Base</robot_base_frame>
                     <odom_publish_frequency>500</odom_publish_frequency>
@@ -108,8 +108,8 @@
             </gazebo>
 
             <gazebo>
-                <plugin filename="ignition-gazebo-imu-system"
-                        name="ignition::gazebo::systems::Imu"/>
+                <plugin filename="gz-sim-imu-system"
+                        name="gz::sim::systems::Imu"/>
             </gazebo>
         </xacro:if>
 


### PR DESCRIPTION
Part of the Ayg JetPack 7 / ROS 2 Jazzy migration (companion PR in the main repo).

Harmonic's plugin loader resolves `gz-sim-*-system` / `gz::sim::systems::*`; the ignition-era names were Fortress-only. 4 lines, runtime-validated: the odometry and IMU plugins publish over the bridge in Harmonic 8.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpomfMXcnQdbA7ZHNUC9km